### PR TITLE
Consolidate time data into one field, reformat recipe list item

### DIFF
--- a/app/src/main/java/com/unoknowbo/recime/database/recipe/Recipe.kt
+++ b/app/src/main/java/com/unoknowbo/recime/database/recipe/Recipe.kt
@@ -6,8 +6,7 @@ import androidx.room.PrimaryKey
 @Entity(tableName = "recipes")
 data class Recipe(
     var name: String,
-    var cookTimeInMinutes: Int,
-    var prepTimeInMinutes: Int,
+    var timeEstimateInMinutes: Int,
     var notes: String,
     @PrimaryKey(autoGenerate = true)
     var id: Long = 0 // Optional parameter because it is auto-generated.

--- a/app/src/main/java/com/unoknowbo/recime/util/BindingUtil.kt
+++ b/app/src/main/java/com/unoknowbo/recime/util/BindingUtil.kt
@@ -4,12 +4,11 @@ import android.widget.TextView
 import androidx.databinding.BindingAdapter
 import com.unoknowbo.recime.database.recipe.Recipe
 
-@BindingAdapter("formattedRecipeTimes")
-fun TextView.formattedRecipeTimes(recipe: Recipe?) {
+@BindingAdapter("formatTime")
+fun TextView.formatTime(recipe: Recipe?) {
     recipe?.let {
-        text = formatRecipeTimes(
-            recipe.cookTimeInMinutes,
-            recipe.prepTimeInMinutes,
+        text = formatTime(
+            recipe.timeEstimateInMinutes,
             context.resources
         )
     }

--- a/app/src/main/java/com/unoknowbo/recime/util/TimeStringUtil.kt
+++ b/app/src/main/java/com/unoknowbo/recime/util/TimeStringUtil.kt
@@ -3,31 +3,21 @@ package com.unoknowbo.recime.util
 import android.content.res.Resources
 import com.unoknowbo.recime.R
 
-fun formatRecipeTimes(cookTimeInMinutes: Int, prepTimeInMinutes: Int, res: Resources): String {
-    return "${res.getString(R.string.prep_colon)} ${formatTime(
-        prepTimeInMinutes,
-        res
-    )}, " +
-            "${res.getString(R.string.cook_colon)} ${formatTime(
-                cookTimeInMinutes,
-                res
-            )}"
-}
-
 fun formatTime(minutes: Int, res: Resources): String {
-    var hoursString = ""
-    if (minutes > 59) {
-        val hours = minutes / 60
-        hoursString += "$hours " + if (hours > 1) res.getString(R.string.hrs) else res.getString(
-            R.string.hr
-        )
-    }
+    var minutesString = ""
     val remainderMinutes = minutes % 60
-    return if (remainderMinutes > 0) {
-        "$hoursString $remainderMinutes " +
-                if (remainderMinutes > 1) res.getString(R.string.mins) else res.getString(R.string.min)
+    val displayMinutes = remainderMinutes > 0
+    if (displayMinutes) {
+        minutesString = "$remainderMinutes" + res.getString(R.string.minutes_abbreviation)
     }
-    else {
-        hoursString
+    return if (minutes > 59) {
+        val hoursString = "${minutes / 60}" + res.getString(R.string.hours_abbreviation)
+        if (displayMinutes) {
+            "$hoursString $minutesString"
+        } else {
+            hoursString
+        }
+    } else {
+        minutesString
     }
 }

--- a/app/src/main/res/drawable/ic_timer.xml
+++ b/app/src/main/res/drawable/ic_timer.xml
@@ -1,0 +1,9 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:fillColor="@color/primaryColor"
+      android:pathData="M15,1L9,1v2h6L15,1zM11,14h2L13,8h-2v6zM19.03,7.39l1.42,-1.42c-0.43,-0.51 -0.9,-0.99 -1.41,-1.41l-1.42,1.42C16.07,4.74 14.12,4 12,4c-4.97,0 -9,4.03 -9,9s4.02,9 9,9 9,-4.03 9,-9c0,-2.12 -0.74,-4.07 -1.97,-5.61zM12,20c-3.87,0 -7,-3.13 -7,-7s3.13,-7 7,-7 7,3.13 7,7 -3.13,7 -7,7z"/>
+</vector>

--- a/app/src/main/res/layout/list_item_recipe.xml
+++ b/app/src/main/res/layout/list_item_recipe.xml
@@ -15,29 +15,43 @@
 
     <LinearLayout
             android:id="@+id/list_item_recipe"
-            android:orientation="vertical"
             android:layout_width="match_parent"
             android:layout_height="wrap_content"
+            android:gravity="center"
             android:padding="@dimen/spacing_normal"
             android:onClick="@{() -> clickListener.onClick(recipe)}">
 
         <TextView
                 android:id="@+id/list_item_recipe_name"
-                android:layout_width="match_parent"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
+                android:layout_weight="10"
                 android:text="@{recipe.name}"
                 android:textColor="@color/primaryColor"
                 android:textSize="@dimen/font_normal"
                 tools:text="Recipe"/>
 
+        <ImageView
+                android:id="@+id/list_item_recipe_timer_icon"
+                android:layout_width="0dp"
+                android:layout_height="wrap_content"
+                android:layout_weight="1"
+                android:layout_marginStart="@dimen/spacing_small"
+                android:layout_marginEnd="@dimen/spacing_small"
+                android:src="@drawable/ic_timer"/>
+
         <TextView
                 android:id="@+id/list_item_recipe_time"
-                android:layout_width="match_parent"
+                android:layout_width="0dp"
                 android:layout_height="wrap_content"
+                android:layout_weight="2"
+                android:maxEms="7"
+                android:minEms="2"
                 android:textColor="@color/primaryLightColor"
                 android:textSize="@dimen/font_small"
-                app:formattedRecipeTimes="@{recipe}"
-                tools:text="Prep: 3 hrs 30 mins, Cook: 1 hr"/>
+                android:textAlignment="center"
+                app:formatTime="@{recipe}"
+                tools:text="12h 30m"/>
     </LinearLayout>
 
 </layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,9 +1,5 @@
 <resources>
     <string name="app_name">Recime</string>
-    <string name="hrs">hrs</string>
-    <string name="hr">hr</string>
-    <string name="mins">mins</string>
-    <string name="min">min</string>
-    <string name="cook_colon">Cook:</string>
-    <string name="prep_colon">Prep:</string>
+    <string name="hours_abbreviation">h</string>
+    <string name="minutes_abbreviation">m</string>
 </resources>


### PR DESCRIPTION
Instead of cook and prep time, have only one total time field
in the recipe table, which is more applicable to a wider array of
recipes.

Reformat the recipe list item to include a timer icon and the
total time, which are right aligned on the same line as the recipe
name.

Remove util functions and strings associated with prep/cook time.